### PR TITLE
Add files param to package.json to reduce file size of npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "test": "gulp test",
     "flow": "flow; test $? -eq 0 -o $? -eq 2"
   },
+  "files": [
+    "dist/checkout.lib.js",
+    "dist/checkout.lib.js.map",
+    "src/"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.paypal.com/paypal/paypal-checkout.git"


### PR DESCRIPTION
On master, this module currently package up 169 files amounting to 4.4 MB. By specifying only the `dist` directory in the package.json, we can eliminate the test and example app code from `npm` and bring it down to 10 files amounting to 1.2 MB.

I wrote a small module to assist with showing what is getting packaged up called `npm-unpack`.

```bash
$ npm i -g npm-unpack
$ npm-unpack
Packing paypal-checkout@4.0.39...

Number of files: 10

package.json
README.md
index.js
LICENSE.txt
dist/checkout.js
dist/checkout.lib.js
dist/checkout.min.js
dist/checkout.js.map
dist/checkout.lib.js.map
dist/checkout.min.js.map
```