### PR TITLE
Fix WARN on npm install command

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,7 @@
     "krakenjs",
     "kraken"
   ],
-  "licenses": [
-    {
-      "type": "Apache 2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    }
-  ],
+  "license" : "Apache-2.0",
   "readmeFilename": "README.md",
   "devDependencies": {
     "babel-core": "^6.7.7",


### PR DESCRIPTION
`npm install` was providing a WARN as it was using deprecated `licenses` property. 
```node
$ npm install
npm WARN paypal-checkout@4.0.46 license should be a valid SPDX license expression
$
```
This change is to use the `license` property per https://docs.npmjs.com/files/package.json#license.