### PR TITLE
Pass minify parameter so minimization will happen in build.

### DIFF
--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -92,12 +92,14 @@ export let WEBPACK_CONFIG_MINOR = getWebpackConfig({
 
 export let WEBPACK_CONFIG_MAJOR_MIN = getWebpackConfig({
     version: nextMajorVersion,
-    filename: `${FILE_NAME}.min.js`
+    filename: `${FILE_NAME}.min.js`,
+    minify: true
 });
 
 export let WEBPACK_CONFIG_MINOR_MIN = getWebpackConfig({
     version: nextMinorVersion,
-    filename: `${FILE_NAME}.${nextMinorVersion}.min.js`
+    filename: `${FILE_NAME}.${nextMinorVersion}.min.js`,
+    minify: true
 });
 
 export let WEBPACK_CONFIG_LIB = getWebpackConfig({


### PR DESCRIPTION
I see in #44 the background on why we are not pushing the minified JS in our documentation at the moment. With that said, there is a checkout.min.js being built but it is not minified as the parameter to enable the minification is not passed. This PR enables it so the minified version exists correctly even if not (yet) noted in documentation.

I fully understand this may be something we do not want to do because of the discussion in #44, but I think having it there for merchants who want to use it but not having the documentation point to it can be helpful.

For reference, enabling minification shrinks the file by about 50%. It is still large, but this is more manageable.

```shell
$ la dist/checkout.4.0.47*js
-rw-r--r--  1 ehummel  110057925   463K Mar  6 13:34 dist/checkout.4.0.47.min.js
-rw-r--r--  1 ehummel  110057925   849K Mar  6 13:34 dist/checkout.4.0.47.js
```