### PR TITLE
(feat): Log prefix parameter on script tag

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,7 +32,8 @@
         "__MINOR_VERSION__": true,
         "__MAJOR_VERSION__": true,
         "__FILE_NAME__": true,
-        "__FILE_VERSION__": true
+        "__FILE_VERSION__": true,
+        "HTMLElement": true
     },
 
     "fix": true,

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -4,7 +4,11 @@ import postRobot from 'post-robot/src';
 import $logger from 'beaver-logger/client';
 import { config } from '../config';
 
-export function initLogger() {
+type LoggerOptions = {
+    loggerPrefix? : string
+};
+
+export function initLogger(options : LoggerOptions) {
 
     $logger.addPayloadBuilder(() => {
         return {
@@ -28,7 +32,7 @@ export function initLogger() {
         uri: config.loggerUrl,
         heartbeat: false,
         logPerformance: false,
-        prefix: `ppxo`
+        prefix: options.logPrefix || `ppxo`
     });
 }
 

--- a/src/setup.js
+++ b/src/setup.js
@@ -27,8 +27,6 @@ function setDomainEnv(domain : string) {
 
 setDomainEnv(`${window.location.protocol}//${window.location.host}`);
 
-initLogger();
-
 SyncPromise.onPossiblyUnhandledException((err : Error) => {
 
     beacon(`unhandled_error`, {
@@ -54,13 +52,19 @@ function getCurrentScript() : ? HTMLScriptElement {
     }
 
     if (document.currentScript) {
-        $logger.debug(`current_script_not_recognized`, { src: document.currentScript.src });
+        //  Logger not inited yet: $logger.debug(`current_script_not_recognized`, { src: document.currentScript.src });
     }
 }
 
 let currentScript = getCurrentScript();
 let currentProtocol = window.location.protocol.split(':')[0];
 
+let prefix = 'ppxo';
+if (currentScript && currentScript instanceof HTMLElement) {
+    prefix = currentScript.getAttribute('data-log-prefix');
+}
+
+initLogger({ logPrefix:  prefix});
 
 type SetupOptions = {
     env? : ?string,


### PR DESCRIPTION
I commented out one log line in getCurrentScript since $logger wouldn't be initialized yet... I can change it to console.log if you want.

There are probably better ways to accomplish this but this is the least intrusive. 

Other than that it seems to be working, but the build process is still not working quite right so I am not 100% sure.