### PR TITLE
fix(Logger): Point client-side logs at /xoplatform/logger

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -162,7 +162,7 @@ export let config = {
         return config.buttonJSUrls[config.env];
     },
 
-    loggerUri: `/webapps/hermes/api/logger`,
+    loggerUri: `/xoplatform/logger/api/logger`,
 
     get bridgeUri() : string {
         return `${config.bridgeUris[config.env]}?xcomponent=1&version=${config.ppobjects ? __FILE_VERSION__ : __MINOR_VERSION__}`;

--- a/src/lib/beacon.js
+++ b/src/lib/beacon.js
@@ -2,7 +2,7 @@
 
 import { config, LOG_LEVEL } from '../config';
 
-const BEACON_URL = 'https://www.paypal.com/webapps/hermes/api/logger';
+const BEACON_URL = 'https://www.paypal.com/xoplatform/logger/api/logger';
 
 export function beacon(event : string, payload : Object = {}) {
     try {


### PR DESCRIPTION
Point client-side logs at `/xoplatform/logger`, rather than `/webapps/hermes`.  `/xoplatform/logger` is a new endpoint for client-side logs, `/webapps/hermes/api/logger` will be deprecated soon.

Tests pass.  And `demo/button.htm` works.

<img width="682" alt="screen shot 2017-03-08 at 12 01 02" src="https://cloud.githubusercontent.com/assets/742884/23721532/00e1a080-03f7-11e7-8f33-f6ebaf40f0df.png">
