### PR TITLE
Simplified Braintree Integration

### DIFF
--- a/src/components/button/braintree.js
+++ b/src/components/button/braintree.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+import { SyncPromise } from 'sync-browser-mocks/src/promise';
+
+export type Braintree = {
+    client : {
+        create : Function
+    },
+    paypalCheckout : {
+        create : Function
+    }
+};
+
+export type BraintreePayPalClient = {
+    createPayment : Function,
+    tokenizePayment : Function
+};
+
+export function awaitBraintreeClient(braintree : Braintree, authorization : string) : SyncPromise<BraintreePayPalClient> {
+    return braintree.client.create({ authorization }).then(client => {
+        return braintree.paypalCheckout.create({ client });
+    });
+}

--- a/test/tests/button/braintree.js
+++ b/test/tests/button/braintree.js
@@ -1,0 +1,128 @@
+/* @flow */
+
+let SyncPromise = window.paypal.Promise;
+
+import { createTestContainer, destroyTestContainer, generatePaymentID } from '../common';
+
+const MOCK_BRAINTREE_AUTH = 'MOCK_BRAINTREE_AUTH';
+const MOCK_BRAINTREE_NONCE = 'MOCK_BRAINTREE_NONCE';
+
+let mockBraintree = {
+
+    client: {
+        create(options) : SyncPromise<mixed> {
+            return SyncPromise.try(() => {
+                if (!options || typeof options !== 'object') {
+                    throw new Error(`Braintree expected options to be passed as an object`);
+                }
+
+                if (options.authorization !== MOCK_BRAINTREE_AUTH) {
+                    throw new Error(`Braintree expected authorization to be ${MOCK_BRAINTREE_AUTH}`);
+                }
+
+                return {};
+            });
+        }
+    },
+
+    paypalCheckout: {
+        create(options) : SyncPromise<mixed> {
+            return SyncPromise.try(() => {
+
+                if (!options || typeof options !== 'object') {
+                    throw new Error(`Braintree expected options to be passed as an object`);
+                }
+
+                if (!options.client) {
+                    throw new Error(`Braintree expected options.client to be passed`);
+                }
+
+                return {
+
+                    createPayment(paymentOptions) : SyncPromise<string> {
+                        return SyncPromise.try(() => {
+
+                            if (!options || typeof options !== 'object') {
+                                throw new Error(`Braintree expected payment options to be passed as an object`);
+                            }
+
+                            return generatePaymentID();
+                        });
+                    },
+
+                    tokenizePayment(data) : SyncPromise<{ nonce : string }> {
+                        return SyncPromise.try(() => {
+
+                            if (!data || typeof data !== 'object') {
+                                throw new Error(`Braintree expected tokenize data to be passed as an object`);
+                            }
+
+                            if (!data.payerID) {
+                                throw new Error(`Braintree expected payerID to be passed`);
+                            }
+
+                            return {
+                                nonce: MOCK_BRAINTREE_NONCE
+                            };
+                        });
+                    }
+                };
+            });
+        }
+    }
+};
+
+
+for (let flow of [ 'popup', 'iframe' ]) {
+
+    describe(`paypal button braintree tests on.only ${flow}`, () => {
+
+        beforeEach(() => {
+            createTestContainer();
+            window.paypal.Checkout.contexts.iframe = (flow === 'iframe');
+        });
+
+        afterEach(() => {
+            destroyTestContainer();
+            window.location.hash = '';
+            window.paypal.Checkout.contexts.iframe = false;
+        });
+
+        it('should render a button into a container and click on the button, then complete the payment', (done) => {
+
+            return window.paypal.Button.render({
+
+                test: { flow, action: 'checkout' },
+
+                braintree: mockBraintree,
+
+                client: {
+                    test: MOCK_BRAINTREE_AUTH
+                },
+
+                payment(actions) : SyncPromise<string> {
+                    return actions.braintree.create({
+                        flow:     'checkout',
+                        amount:   '1.00',
+                        currency: 'USD',
+                        intent:   'sale'
+                    });
+                },
+
+                onAuthorize(data) : void {
+
+                    if (data.nonce !== MOCK_BRAINTREE_NONCE) {
+                        return done(new Error(`Expected data.nonce to be ${MOCK_BRAINTREE_NONCE}, got ${data.nonce}`));
+                    }
+
+                    return done();
+                },
+
+                onCancel() : void {
+                    return done(new Error('Expected onCancel to not be called'));
+                }
+
+            }, '#testContainer');
+        });
+    });
+}

--- a/test/tests/button/index.js
+++ b/test/tests/button/index.js
@@ -8,3 +8,4 @@ export * from './frame';
 export * from './popupBridge';
 export * from './displayto';
 export * from './size';
+export * from './braintree';

--- a/test/windows/checkout/index.js
+++ b/test/windows/checkout/index.js
@@ -29,6 +29,8 @@ if (action === 'checkout') {
 
             window.xprops.onAuthorize({
                 paymentToken,
+                paymentID: paymentToken,
+                payerID: 'YYYYYYYYYYYYY',
                 cancelUrl: `#cancel?token=${paymentToken}${ hash }`,
                 returnUrl: `#return?token=${paymentToken}&PayerID=YYYYYYYYYYYYY${ hash }`,
                 currentUrl: window.location.href


### PR DESCRIPTION
Allows integrating Braintree with the following pattern:

```javascript
paypal.Button.render({
    
    env: 'sandbox',
    
    braintree: braintree,
    
    client: {
        sandbox: 'SANDBOX_AUTH',
        production: 'PRODUCTION_AUTH'
    },
    
    payment: function(actions) {
        return actions.braintree.create({
            flow:     'checkout',
            amount:   '1.00',
            currency: 'USD',
            intent:   'sale'
        });
    },

    onAuthorize: function(data, actions) {
        console.log('Nonce:', data.nonce);
    }

}, '#paypal-button-container');
```

The objective of this is:

- Less boilerplate
- Easier to upgrade from a REST integration to Braintree
- Normalizes the integration patterns even further
- Parallelizes the Braintree client creation and the paypal.Button rendering