### PR TITLE
Clean up console output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ gulp build
 ```
 
 
+To enable output of additional debugging messages to the console, set the `data-log-level` attribute of the script element to e.g. `info` (default value is `warn`):
+
+   ```html
+   <script src="https://www.paypalobjects.com/api/checkout.js" data-version-4 data-log-level="info"></script>
+    ```
+
 ## Test Tasks
 ```
 gulp test

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -72,7 +72,7 @@ function getWebpackConfig({ version, filename, modulename, target = 'window', mi
                 __LEGACY_SUPPORT__: JSON.stringify(true),
                 __FILE_NAME__: JSON.stringify(filename),
                 __FILE_VERSION__: JSON.stringify(version),
-                __DEFAULT_LOG_LEVEL__: JSON.stringify('info'),
+                __DEFAULT_LOG_LEVEL__: JSON.stringify('warn'),
                 __CHILD_WINDOW_ENFORCE_LOG_LEVEL__: JSON.stringify(true),
                 __SEND_POPUP_LOGS_TO_OPENER__: JSON.stringify(true),
                 ...vars,


### PR DESCRIPTION
Hide internal debugging messages to console by default, see #315.