### PR TITLE
Buy Now Button bug fix

### DIFF
--- a/src/components/button/templates/component/style.js
+++ b/src/components/button/templates/component/style.js
@@ -415,7 +415,9 @@ export let componentStyle = `
      }
 
      .paypal-button.paypal-branding-false .paypal-button-content  {
-            width: 60%;
+            width: auto;
+            display: inline-block;
+            max-width: 100%;
             margin: auto;
             font-weight: 900;
      }


### PR DESCRIPTION
Buy Now button wasn't displaying text for some locales since the text was overflowing on the button's content area.
Solution:
Make the size of the unbranded button fit the actual text. So, now size varies according to the text.