### PR TITLE
feat(rest): Add execute api

### DIFF
--- a/src/api/rest.js
+++ b/src/api/rest.js
@@ -381,7 +381,7 @@ function executeToken(env : string, client : { [key : string] : string }, paymen
         logPaymentResponse(res);
 
         if (res && res.id) {
-            return res.id;
+            return res;
         }
 
         throw new Error(`Payment Execute Api response error:\n\n${ JSON.stringify(res, null, 4) }`);

--- a/src/api/rest.js
+++ b/src/api/rest.js
@@ -333,9 +333,65 @@ export function createBillingToken(env : string, client : { [key : string] : str
     });
 }
 
+function executeToken(env : string, client : { [key : string] : string }, paymentDetails : Object) : ZalgoPromise<string> {
+
+    info(`rest_api_execute_token`);
+
+    env = env || config.env;
+
+    let clientID = client[env];
+
+    if (!clientID) {
+        throw new Error(`Client ID not found for env: ${ env }`);
+    }
+
+    let { payer_id, payment_id, meta } = paymentDetails;
+
+    if (!payment_id || !payer_id) {
+        throw new Error(`Expected payer_id and payment_id to be passed`);
+    }
+    /*
+    if (proxyRest.createCheckoutToken && !proxyRest.createCheckoutToken.source.closed) {
+        return proxyRest.createCheckoutToken(env, client, { payment, experience, meta });
+    }
+    */
+
+    return createAccessToken(env, client).then((accessToken) : ZalgoPromise<Object> => {
+
+        return ZalgoPromise.try(() : ZalgoPromise<Object> => {
+
+            let headers : Object = {
+                Authorization: `Bearer ${ accessToken }`
+            };
+
+            if (meta && meta.partner_attribution_id) {
+                headers['PayPal-Partner-Attribution-Id'] = meta.partner_attribution_id;
+            }
+
+            return request({
+                method: `post`,
+                url:    `${ config.paymentApiUrls[env] }/${ payment_id }/execute`,
+                headers,
+                json:   { payer_id }
+            });
+        });
+
+    }).then((res) : string => {
+
+        logPaymentResponse(res);
+
+        if (res && res.id) {
+            return res.id;
+        }
+
+        throw new Error(`Payment Execute Api response error:\n\n${ JSON.stringify(res, null, 4) }`);
+    });
+}
+
 export let rest = {
     payment: {
-        create: createCheckoutToken
+        create: createCheckoutToken,
+        execute: executeToken
     },
     order: {
         create: createOrderToken


### PR DESCRIPTION
payment token execute function.  This allows merchants the ability to save the paymentID and payer_id in a cookie, do a redirect, and run execute later.

![image](https://user-images.githubusercontent.com/3578259/34274713-695c4a8e-e65f-11e7-85aa-7bdc16d17dfb.png)

![image](https://user-images.githubusercontent.com/3578259/34274721-765a8d72-e65f-11e7-8d8e-97a21f272310.png)
