### PR TITLE
Log errors and warnings silently

### DIFF
--- a/src/external/pptm.js
+++ b/src/external/pptm.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { track, warn, error } from 'beaver-logger/client';
+import { track, info } from 'beaver-logger/client';
 
 import { config } from '../config';
 import { FPTI, PPTM_ID } from '../constants';
@@ -16,7 +16,7 @@ export function createPptmScript() {
     const alreadyDownloaded = Boolean(getElement(PPTM_ID));
 
     if (alreadyDownloaded) {
-        warn(`pptm_tried_loading_twice`);
+        info('pptm_tried_loading_twice');
         return;
     }
 
@@ -25,7 +25,6 @@ export function createPptmScript() {
         [ FPTI.KEY.TRANSITION ]: FPTI.TRANSITION.PPTM_LOAD
     });
 
-    // Works essentially as a NOOP until opt-in
     const fullUrl = extendUrl(config.pptmUrl, {
         t:    'xo',
         id:   window.location.hostname,
@@ -33,13 +32,11 @@ export function createPptmScript() {
     });
 
     loadScript(fullUrl, 0, { async: true, id: PPTM_ID }).then(() => {
-
         track({
             [ FPTI.KEY.STATE ]:      FPTI.STATE.PPTM,
             [ FPTI.KEY.TRANSITION ]: FPTI.TRANSITION.PPTM_LOADED
         });
-
     }).catch(err => {
-        error('pptm_script_error', { error: stringifyError(err) });
+        info('pptm_script_error', { error: stringifyError(err) });
     });
 }


### PR DESCRIPTION
- Use `track` instead of `error` or `warning` when loading `pptm.js`

Closes #548