### PR TITLE
Shipping Options changes

### DIFF
--- a/src/api/hacks.js
+++ b/src/api/hacks.js
@@ -20,10 +20,17 @@ export function validateExtraPaymentOptions(options : Object) {
             throw new TypeError(`Expected shipping_options to be an array`);
         }
 
+        let uniqueIdCheck = {};
         for (let option of options.payer.shipping_options) {
             if (!option.id) {
                 throw new Error(`Expected option.id for shipping_options`);
             }
+
+            if (uniqueIdCheck.hasOwnProperty(option.id)) {
+                throw new Error(`Expected unique option.id for shipping_options`);
+            }
+
+            uniqueIdCheck[option.id] = 'seen';
 
             if (!option.label) {
                 throw new Error(`Expected option.label for shipping_options`);

--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -27,6 +27,7 @@ import { containerTemplate, componentTemplate } from './template';
 import { validateButtonLocale, validateButtonStyle } from './validate';
 import { setupButtonChild } from './child';
 import { normalizeProps } from './props';
+import { mergePaymentDetails } from '../api/hacks';
 
 function isCreditDualEligible(props) : boolean {
 
@@ -527,7 +528,20 @@ export let Button : Component<ButtonOptions> = create({
                                 return new ZalgoPromise();
                             }
 
-                            return result;
+                            return mergePaymentDetails(result.id, result);
+                        });
+                    };
+
+                    let get = actions.payment.get;
+
+                    actions.payment.get = () => {
+                        return get().then(result => {
+                            if (!result || !result.id || !result.intent || !result.state ) {
+                                warn(`get_result_missing_data`);
+                                return new ZalgoPromise();
+                            }
+
+                            return mergePaymentDetails(result.id, result);
                         });
                     };
 

--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -22,12 +22,12 @@ import { getPaymentType, awaitBraintreeClient,
     mapPaymentToBraintree, type BraintreePayPalClient } from '../integrations';
 import { awaitPopupBridge } from '../integrations/popupBridge';
 import { validateFunding, isFundingIneligible, isFundingAutoEligible } from '../funding';
+import { mergePaymentDetails } from '../api/hacks';
 
 import { containerTemplate, componentTemplate } from './template';
 import { validateButtonLocale, validateButtonStyle } from './validate';
 import { setupButtonChild } from './child';
 import { normalizeProps } from './props';
-import { mergePaymentDetails } from '../api/hacks';
 
 function isCreditDualEligible(props) : boolean {
 
@@ -536,7 +536,7 @@ export let Button : Component<ButtonOptions> = create({
 
                     actions.payment.get = () => {
                         return get().then(result => {
-                            if (!result || !result.id || !result.intent || !result.state ) {
+                            if (!result || !result.id || !result.intent || !result.state) {
                                 warn(`get_result_missing_data`);
                                 return new ZalgoPromise();
                             }


### PR DESCRIPTION
Requiring unique IDs for shipping_options.
Merging responses for get and execute payment details with shipping options selection from checkout.