### PR TITLE
Force iframe flow for MacOS CNA (Captive Network Assistant / Captive Portal)

### DIFF
--- a/src/declarations.js
+++ b/src/declarations.js
@@ -6,9 +6,9 @@ declare var __MIN__: boolean;
 declare var __FILE_NAME__ : string;
 
 declare var __PAYPAL_CHECKOUT__ : {
-    __MAJOR_VERSION__ : string;
-    __MINOR_VERSION__ : string;
-    __DEFAULT_LOG_LEVEL__ : string;
-    __LEGACY_SUPPORT__ : boolean;
+    __MAJOR_VERSION__ : string,
+    __MINOR_VERSION__ : string,
+    __DEFAULT_LOG_LEVEL__ : string,
+    __LEGACY_SUPPORT__ : boolean,
     __MAJOR__ : boolean
 }

--- a/src/lib/device.js
+++ b/src/lib/device.js
@@ -121,7 +121,14 @@ export function isIEIntranet() : boolean {
     return false;
 }
 
+export function isMacOsCna() : boolean {
+    let userAgent = getUserAgent();
+    return (/Macintosh.*AppleWebKit(?!.*Safari)/i).test(userAgent) ||
+        (/\bwv\b/).test(userAgent) ||
+    (/Android.*Version\/(\d)\.(\d)/i).test(userAgent);
+}
+
 export function supportsPopups(ua? : string = getUserAgent()) : boolean {
     return !(isIosWebview(ua) || isAndroidWebview(ua) || isOperaMini(ua) ||
-        isFirefoxIOS(ua) || isFacebookWebView(ua) || isQQBrowser(ua) || isElectron());
+        isFirefoxIOS(ua) || isFacebookWebView(ua) || isQQBrowser(ua) || isElectron() || isMacOsCna());
 }

--- a/src/lib/device.js
+++ b/src/lib/device.js
@@ -123,9 +123,7 @@ export function isIEIntranet() : boolean {
 
 export function isMacOsCna() : boolean {
     let userAgent = getUserAgent();
-    return (/Macintosh.*AppleWebKit(?!.*Safari)/i).test(userAgent) ||
-        (/\bwv\b/).test(userAgent) ||
-    (/Android.*Version\/(\d)\.(\d)/i).test(userAgent);
+    return (/Macintosh.*AppleWebKit(?!.*Safari)/i).test(userAgent);
 }
 
 export function supportsPopups(ua? : string = getUserAgent()) : boolean {


### PR DESCRIPTION
When using PayPal checkout in a MacOS CNA (Captive Network Assistant / Captive Portal) window, opening popups and other windows is not supported. This change detects the use of MacOS CNA and forces the iframe flow.