### PR TITLE
adding `getPaymentDetails` to check the state from Checkout Apps

### DIFF
--- a/src/api/hacks.js
+++ b/src/api/hacks.js
@@ -65,6 +65,10 @@ export function addPaymentDetails(id : string, details : Object) {
     payments[id].details = details;
 }
 
+export function getPaymentDetails(id: string) {
+    return payments && payments[id] && payments[id].details;
+}
+
 export function mergePaymentDetails(id : string, payment : Object) : Object {
     payments[id] = payments[id] || {};
     let details = payments[id].details || {};

--- a/src/api/hacks.js
+++ b/src/api/hacks.js
@@ -65,7 +65,7 @@ export function addPaymentDetails(id : string, details : Object) {
     payments[id].details = details;
 }
 
-export function getPaymentDetails(id: string) {
+export function getPaymentDetails(id : string) : ?Object {
     return payments && payments[id] && payments[id].details;
 }
 

--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -16,7 +16,7 @@ import { redirect as redir, checkRecognizedBrowser,
     isIEIntranet, isEligible,
     getDomainSetting, extendUrl, isDevice, rememberFunding,
     getRememberedFunding, memoize, uniqueID, getThrottle, getBrowser } from '../lib';
-import { rest, getPaymentOptions, addPaymentDetails } from '../api';
+import { rest, getPaymentOptions, addPaymentDetails, getPaymentDetails } from '../api';
 import { onAuthorizeListener } from '../experiments';
 import { getPaymentType, awaitBraintreeClient,
     mapPaymentToBraintree, type BraintreePayPalClient } from '../integrations';
@@ -92,7 +92,8 @@ type ButtonOptions = {
     logLevel : string,
     supplement : {
         getPaymentOptions : Function,
-        addPaymentDetails : Function
+        addPaymentDetails : Function,
+        getPaymentDetails: Function
     },
     awaitPopupBridge : Function,
     meta : Object,
@@ -728,7 +729,7 @@ export let Button : Component<ButtonOptions> = create({
         supplement: {
             type:     'object',
             required: false,
-            value:    { getPaymentOptions, addPaymentDetails }
+            value:    { getPaymentOptions, addPaymentDetails, getPaymentDetails }
         },
 
         test: {

--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -93,7 +93,7 @@ type ButtonOptions = {
     supplement : {
         getPaymentOptions : Function,
         addPaymentDetails : Function,
-        getPaymentDetails: Function
+        getPaymentDetails : Function
     },
     awaitPopupBridge : Function,
     meta : Object,


### PR DESCRIPTION
Adding this facilitator so Checkout flows can determine if a transaction has set mandatory payment_details, such as shipping methods. 