### PR TITLE
fix(iframe): Use the iFrame for all standalone apps

### DIFF
--- a/src/lib/device.js
+++ b/src/lib/device.js
@@ -20,6 +20,10 @@ export function isWebView() : boolean {
     (/Android.*Version\/(\d)\.(\d)/i).test(userAgent);
 }
 
+export function isStandAlone() : boolean {
+    return (window.navigator.standalone === true || window.matchMedia('(display-mode: standalone)').matches);
+}
+
 export function isFacebookWebView(ua? : string = getUserAgent()) : boolean {
     return (ua.indexOf('FBAN') !== -1) || (ua.indexOf('FBAV') !== -1);
 }
@@ -128,5 +132,5 @@ export function isMacOsCna() : boolean {
 
 export function supportsPopups(ua? : string = getUserAgent()) : boolean {
     return !(isIosWebview(ua) || isAndroidWebview(ua) || isOperaMini(ua) ||
-        isFirefoxIOS(ua) || isFacebookWebView(ua) || isQQBrowser(ua) || isElectron() || isMacOsCna());
+        isFirefoxIOS(ua) || isFacebookWebView(ua) || isQQBrowser(ua) || isElectron() || isMacOsCna() || isStandAlone());
 }


### PR DESCRIPTION
REF: https://github.com/paypal/paypal-checkout/issues/699

Before, we were using the user-agent to detect whether or not the app was being rendered in an iOS
native web-view. The problem is that PWA's saved to the iOS homescreen were not being treated like
web-views and were still trying to open a pop-up.

Here's the documentation I used to detect "Home Screen" apps: https://developers.google.com/web/fundamentals/app-install-banners/#detect-mode

The caveat is that chrome windows opened using `window.open('...', '_blank');` will also be detected as standalone apps using this logic. 