### PR TITLE
fix(redirect): Fixing `actions.redirect` from within iOS webviews.

### DIFF
--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -652,10 +652,11 @@ export let Button : Component<ButtonOptions> = create({
                     flushLogs();
 
                     let redirect = (win, url) => {
-                        return ZalgoPromise.all([
-                            redir(win || window.top, url || data.cancelUrl),
-                            actions.close()
-                        ]);
+                        return ZalgoPromise.try(() => {
+                            return actions.close();
+                        }).then(() => {
+                            return redir(win || window.top, url || data.cancelUrl);
+                        });
                     };
 
                     return original.call(this, data, { ...actions, redirect });

--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -14,7 +14,7 @@ import { SOURCE, ENV, FPTI, FUNDING, BUTTON_LABEL, BUTTON_COLOR,
 import { redirect as redir, checkRecognizedBrowser,
     getBrowserLocale, getSessionID, request, getScriptVersion,
     isIEIntranet, isEligible,
-    getDomainSetting, extendUrl, isDevice, isIosWebview, rememberFunding,
+    getDomainSetting, extendUrl, isDevice, rememberFunding,
     getRememberedFunding, memoize, uniqueID, getThrottle, getBrowser } from '../lib';
 import { rest, getPaymentOptions, addPaymentDetails, getPaymentDetails } from '../api';
 import { onAuthorizeListener } from '../experiments';
@@ -551,15 +551,11 @@ export let Button : Component<ButtonOptions> = create({
                     };
 
                     actions.redirect = (win, url) => {
-                        if (isIosWebview()) {
-                            return ZalgoPromise.try(() =>
-                                actions.close()
-                            ).then(() =>
-                                redir(win || window.top, url || data.returnUrl)
-                            );
-                        }
-
-                        return ZalgoPromise.all([ actions.close(), redir(win || window.top, url || data.returnUrl) ]);
+                        return ZalgoPromise.try(() => {
+                            return actions.close();
+                        }).then(() => {
+                            return redir(win || window.top, url || data.returnUrl);
+                        });
                     };
 
                     actions.payment.tokenize = memoize(() => {


### PR DESCRIPTION
REF: https://github.com/paypal/paypal-checkout/issues/736

In a native iOS webview, the merchant page cannot perform a redirect until the iframe has been
closed. So the logic is now procedural just for iOS (close -> redirect)