### PR TITLE
Point client-side logs at /xoplatform/logger, not /webapps/hermes

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -431,7 +431,7 @@ export let config = {
 
     hermesLoggerUri: `/webapps/hermes/api/logger`,
 
-    loggerUri: `/xoplatform/logger`,
+    loggerUri: `/xoplatform/logger/api/logger`,
 
     loggerThrottlePercentage: 0.05, // 5%
 
@@ -727,7 +727,10 @@ export let config = {
     },
 
     get loggerUrl() : string {
-        return `${ config.paypalUrl }${ config.hermesLoggerUri }`;
+        let isTestExperiment = Math.random() < config.loggerThrottlePercentage;
+        let loggerUrl = isTestExperiment ? config.loggerUri : config.hermesLoggerUri;
+
+        return `${ config.paypalUrl }${ loggerUrl }`;
     },
 
     get pptmUrl() : string {

--- a/src/lib/beacon.js
+++ b/src/lib/beacon.js
@@ -5,7 +5,8 @@ import { LOG_LEVEL } from '../constants';
 
 import { getSessionID, getSessionState } from './session';
 
-const BEACON_URL = 'https://www.paypal.com/webapps/hermes/api/logger';
+const BEACON_URL = config.loggerUrl;
+const APP_NAME = 'checkoutjs';
 
 export function beacon(event : string, payload : Object = {}) {
     try {
@@ -14,6 +15,7 @@ export function beacon(event : string, payload : Object = {}) {
         payload.version = __PAYPAL_CHECKOUT__.__MINOR_VERSION__;
         payload.host = window.location.host;
         payload.uid = getSessionID();
+        payload.appName = APP_NAME;
 
         let query = [];
 

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { CONFIG as POSTROBOT_CONFIG } from 'post-robot/src';
-import { setTransport, getTransport, addPayloadBuilder, addMetaBuilder,
+import { setTransport, getTransport, addPayloadBuilder, addHeaderBuilder, addMetaBuilder,
     addTrackingBuilder, init, logLevels, config as loggerConfig } from 'beaver-logger/client';
 import { getParent } from 'cross-domain-utils/src';
 
@@ -49,6 +49,12 @@ export function initLogger() {
             lang:    config.locale.lang,
             uid:     getSessionID(),
             ver:     __PAYPAL_CHECKOUT__.__MINOR_VERSION__
+        };
+    });
+
+    addHeaderBuilder(() => {
+        return {
+            'x-app-name': 'checkoutjs'
         };
     });
 


### PR DESCRIPTION
*Changes*
- Running a 5% test for ramping logs (src/lib/logger) to
  /xoplatform/logger
- Pointing all beacon logs (src/lib/beacon) to /xoplatform/logger

*NOTE* This is similar to https://github.com/paypal/paypal-checkout/pull/260 which never actually landed :-)  Now we're getting around to finally ramping up our logs onto another URL.

![img](https://media2.giphy.com/media/26vIfKDKOw34lHRks/giphy.gif)