### PR TITLE
Removing searsoutlet.com from venmo blacklist

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -149,10 +149,6 @@ export let config = {
             disable_venmo: true
         },
 
-        'searsoutlet.com': {
-            disable_venmo: true
-        },
-
         'searshometownstores.com': {
             disable_venmo: true
         },


### PR DESCRIPTION
Searsoutlet stoped using Billing agreements, so we should be able to support this.