### PR TITLE
Allow full response to be passed through in Component.jsx

### DIFF
--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -570,7 +570,7 @@ export let Button : Component<ButtonOptions> = create({
 
                         return this.props.braintree
                             .then(client => client.tokenizePayment(data))
-                            .then(res => ({ nonce: res.nonce }));
+                            .then(res => res);
                     });
 
                     let execute = actions.payment.execute;

--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -569,8 +569,7 @@ export let Button : Component<ButtonOptions> = create({
                         }
 
                         return this.props.braintree
-                            .then(client => client.tokenizePayment(data))
-                            .then(res => res);
+                            .then(client => client.tokenizePayment(data));
                     });
 
                     let execute = actions.payment.execute;


### PR DESCRIPTION
Here's my attempt at a PR to address https://github.com/paypal/paypal-checkout/issues/815

## Problem summary
The basic summary of the problem was that the current implementation of `Component.jsx` strips out attributes that aren't the `nonce`. This prevents flows were a PayPal client wishes to collect a customers shipping address and having it returned with the nonce.

## Proposed solution
This is the simplest approach and simply allows the full `response` object to be passed through unchanged.

Here's where the payload gets created in `braintree-web`
https://github.com/braintree/braintree-web/blob/master/src/paypal-checkout/paypal-checkout.js#L405

## Extra notes
I'm not confident that this PR correctly tags the types as I'm not too familiar with flow and the two attributes I've added are of type `Object` with what I assume are changeable properties.

I hope this is at least a jumping off point for a discussion 😄 

Thanks in advance