### PR TITLE
(fix)Removing webviews, Edge for IOS, and Firefox for IOS form Venmo button eligibility

### DIFF
--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -15,7 +15,8 @@ import { redirect as redir, checkRecognizedBrowser,
     getBrowserLocale, getPotentiallyBetterBrowserLocale, getSessionID, request, getScriptVersion,
     isIEIntranet, isEligible,
     getDomainSetting, extendUrl, isDevice, rememberFunding,
-    getRememberedFunding, memoize, uniqueID, getThrottle, getBrowser } from '../lib';
+    getRememberedFunding, memoize, uniqueID, getThrottle,
+    getBrowser, isWebView, isEdgeIOS, isFirefoxIOS } from '../lib';
 import { rest, getPaymentOptions, addPaymentDetails, getPaymentDetails } from '../api';
 import { onAuthorizeListener } from '../experiments';
 import { getPaymentType, awaitBraintreeClient,
@@ -442,10 +443,13 @@ export let Button : Component<ButtonOptions> = create({
 
                 let remembered = getRememberedFunding(sources => sources);
 
-                // Uncookied venmo ramp. Even without 'pwv' cookie, we'll be rendering venmo button
-                // for a sample of the mobile population.
+                /* Uncookied venmo ramp. Even without 'pwv' cookie, we'll be rendering venmo button
+                    for a sample of the mobile population.
+                    Webviews, EdgeIOS, and FirefoxIOS do NOT qualify for this experiment
+                 */
                 if (allowed && allowed.indexOf(FUNDING.VENMO) === -1 &&
-                    remembered && remembered.indexOf(FUNDING.VENMO) === -1 && isDevice()) {
+                    remembered && remembered.indexOf(FUNDING.VENMO) === -1 &&
+                    isDevice() && !isWebView() && !isEdgeIOS() && !isFirefoxIOS()) {
 
                     venmoThrottle = getThrottle('venmo_uncookied_render', 10);
 

--- a/src/lib/device.js
+++ b/src/lib/device.js
@@ -13,16 +13,6 @@ export function isDevice() : boolean {
     return false;
 }
 
-export function isWebView() : boolean {
-    let userAgent = getUserAgent();
-    return isFacebookWebView() ||
-            isIosWebview() ||
-            isAndroidWebview() ||
-        (/(iPhone|iPod|iPad|Macintosh).*AppleWebKit(?!.*Safari)/i).test(userAgent) ||
-        (/\bwv\b/).test(userAgent) ||
-    (/Android.*Version\/(\d)\.(\d)/i).test(userAgent);
-}
-
 export function isStandAlone() : boolean {
     return (window.navigator.standalone === true || window.matchMedia('(display-mode: standalone)').matches);
 }
@@ -74,6 +64,12 @@ export function isAndroidWebview(ua? : string = getUserAgent()) : boolean {
         return (/Version\/[\d.]+/).test(ua) && !isOperaMini(ua);
     }
     return false;
+}
+
+export function isWebView() : boolean {
+    return isFacebookWebView() ||
+        isIosWebview() ||
+        isAndroidWebview();
 }
 
 export function isIE() : boolean {

--- a/src/lib/device.js
+++ b/src/lib/device.js
@@ -15,7 +15,10 @@ export function isDevice() : boolean {
 
 export function isWebView() : boolean {
     let userAgent = getUserAgent();
-    return (/(iPhone|iPod|iPad|Macintosh).*AppleWebKit(?!.*Safari)/i).test(userAgent) ||
+    return isFacebookWebView() ||
+            isIosWebview() ||
+            isAndroidWebview() ||
+        (/(iPhone|iPod|iPad|Macintosh).*AppleWebKit(?!.*Safari)/i).test(userAgent) ||
         (/\bwv\b/).test(userAgent) ||
     (/Android.*Version\/(\d)\.(\d)/i).test(userAgent);
 }


### PR DESCRIPTION
Webviews don't allow for the Venmo App switch on mobile devices. 
Third party browsers on iOS would not support app switch as well as that is native to Safari