### PR TITLE
Only display label "powered by PayPal" when FUNDING.CARD is allowed

### DIFF
--- a/src/button/template/componentTemplate.jsx
+++ b/src/button/template/componentTemplate.jsx
@@ -284,9 +284,15 @@ function renderPowerByPaypalLogo(props) : ChildType {
         return null;
     }
 
-    const { layout, size } = props;
+    const { layout, size, sources = [] } = props;
 
     if (!(layout === BUTTON_LAYOUT.VERTICAL && (size === BUTTON_SIZE.MEDIUM || size === BUTTON_SIZE.LARGE || size === BUTTON_SIZE.HUGE))) {
+        return null;
+    }
+
+    const isCardDisallowed = sources.indexOf(FUNDING.CARD) === -1;
+
+    if (isCardDisallowed) {
         return null;
     }
 

--- a/src/button/template/containerTemplate.jsx
+++ b/src/button/template/containerTemplate.jsx
@@ -1,7 +1,7 @@
 /* @flow */
 /* @jsx jsxDom */
 
-import { BUTTON_SIZE, BUTTON_LAYOUT } from '../../constants';
+import { BUTTON_SIZE, BUTTON_LAYOUT, FUNDING } from '../../constants';
 import { getButtonConfig, BUTTON_STYLE, BUTTON_RELATIVE_STYLE } from '../config';
 import { normalizeProps } from '../props';
 import { values, min, max, perc } from '../../lib/util';
@@ -43,7 +43,7 @@ function determineResponsiveSize({ label, layout, width = 0 }) : string {
     throw new Error(`Unable to calculate responsive size for width: ${ width }`);
 }
 
-function getDimensions({ label, size, tagline, fundingicons, layout, number, viewport, height: buttonHeight, cards }) : DimensionsType {
+function getDimensions({ label, size, tagline, fundingicons, layout, number, viewport, height: buttonHeight, cards, sources = [] }) : DimensionsType {
 
     if (size === BUTTON_SIZE.RESPONSIVE) {
         size = determineResponsiveSize({ label, layout, width: viewport.width, height: buttonHeight });
@@ -64,7 +64,9 @@ function getDimensions({ label, size, tagline, fundingicons, layout, number, vie
         height = (buttonHeight * number) + (perc(buttonHeight, BUTTON_RELATIVE_STYLE.VERTICAL_MARGIN) * (number - 1));
     }
 
-    if ((cards && cards.length > 0) && layout === BUTTON_LAYOUT.VERTICAL) {
+    const isCardFundingAllowed = sources.indexOf(FUNDING.CARD) >= 0;
+
+    if (isCardFundingAllowed && (cards && cards.length > 0) && layout === BUTTON_LAYOUT.VERTICAL) {
         height += BUTTON_STYLE[size].byPayPalHeight;
     }
 
@@ -93,7 +95,8 @@ export function containerTemplate({ id, props, CLASS, on, container, tag, contex
             fundingicons,
             tagline,
             layout,
-            cards
+            cards,
+            sources
         });
     };
 


### PR DESCRIPTION
This PR will fix #830 

In details: Check to see if `FUNDING.CARD` is disallowed before calculating the height for SPB and displaying the "powered by PayPal" label.