### PR TITLE
fix the issue that does not show inline guest

### DIFF
--- a/src/button/template/componentTemplate.jsx
+++ b/src/button/template/componentTemplate.jsx
@@ -89,6 +89,9 @@ function renderCards({ cards, button, layout, size } :
                 class={ `${ button ? CLASS.BUTTON : '' } ${ CLASS.CARD } ${ CLASS.CARD }-${ name }` }
                 tabindex='0'>
                 <img
+                    { ...{ [ATTRIBUTE.LAYOUT]: layout ? layout : '' } }
+                    { ...{ [ATTRIBUTE.SIZE]: size ? size : '' } }
+                    { ...{ [ATTRIBUTE.BUTTON]: (button || false), [ATTRIBUTE.FUNDING_SOURCE]: `${ FUNDING.CARD }`, [ATTRIBUTE.CARD]: `${ name }` } }
                     src={ `data:image/svg+xml;base64,${ btoa(logo) }` }
                     alt={ name } />
             </div>


### PR DESCRIPTION
**The root cause:**

We get to the `layout` and `size` from the credit card element to determine whether we should Inline Guest or not. But the recent commit added wrapper `div` and removed all the attributes from old element (which was an image), that's why we cannot get the `layout` and `size` anymore and it always opens the guest flow instead of inline guest.

The ultimate solution will be not relying on the `event.target`, use the `event.currentTarget` instead.