### PR TITLE
fix the missing funding icons bug

### DIFF
--- a/src/button/template/componentTemplate.jsx
+++ b/src/button/template/componentTemplate.jsx
@@ -92,6 +92,7 @@ function renderCards({ cards, button, layout, size } :
                     { ...{ [ATTRIBUTE.LAYOUT]: layout ? layout : '' } }
                     { ...{ [ATTRIBUTE.SIZE]: size ? size : '' } }
                     { ...{ [ATTRIBUTE.BUTTON]: (button || false), [ATTRIBUTE.FUNDING_SOURCE]: `${ FUNDING.CARD }`, [ATTRIBUTE.CARD]: `${ name }` } }
+                    style={ ` display: block; ` }
                     src={ `data:image/svg+xml;base64,${ btoa(logo) }` }
                     alt={ name } />
             </div>


### PR DESCRIPTION
TLDR:

On chrome, there is 1 extra padding pixel on the image element. It makes the `offsetHeight` and `scrollHeight` difference and we have the logic to hide the funding icons if those values are not the same.