### PR TITLE
Adding domain to Venmo blacklist

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -239,6 +239,10 @@ export let config = {
 
         'zulily.com': {
             disable_venmo: true
+        },
+
+        'freshly.com': {
+            disable_venmo: true
         }
     },
 


### PR DESCRIPTION
'freshly.com' is a Billing agreement merchant.