### PR TITLE
Updated package.json `repository.url`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.paypal.com/paypal/paypal-checkout.git"
+    "url": "git://github.com/paypal/paypal-checkout.git"
   },
   "homepage": "https://developer.paypal.com/",
   "keywords": [


### PR DESCRIPTION
Updated package.json `repository.url` to point to github.com, rather than github.paypal.com. This should fix the broken link from the [paypal-checkout npmjs.com](https://www.npmjs.com/package/paypal-checkout) page.