### PR TITLE
fix(iframe-standalone): Preventing chrome popup windows from opening checkout in iframe

### DIFF
--- a/src/lib/device.js
+++ b/src/lib/device.js
@@ -13,8 +13,13 @@ export function isDevice() : boolean {
     return false;
 }
 
+export function isPopup() : boolean {
+    return (window.opener && window.opener !== window);
+}
+
 export function isStandAlone() : boolean {
-    return (window.navigator.standalone === true || window.matchMedia('(display-mode: standalone)').matches);
+    // Chrome interprets pop-up windows as standalone windows
+    return !isPopup() && (window.navigator.standalone === true || window.matchMedia('(display-mode: standalone)').matches);
 }
 
 export function isFacebookWebView(ua? : string = getUserAgent()) : boolean {


### PR DESCRIPTION
Chrome counts both homescreen PWA's and popup windows as standalone
windows. We only want to show the iFrame for homescreen PWA's.