### PR TITLE
fix(error-focus-closed): Remove error when focusing on closed window

### DIFF
--- a/src/checkout/template/containerTemplate.jsx
+++ b/src/checkout/template/containerTemplate.jsx
@@ -64,7 +64,12 @@ export function containerTemplate({ id, props, CLASS, ANIMATION, CONTEXT, EVENT,
             // eslint-disable-next-line no-alert
             window.alert('Please switch tabs to reactivate the PayPal window');
         } else {
-            actions.focus();
+            try {
+                actions.focus();
+            } catch (err) {
+                // There's no more window to focus on
+                actions.close();
+            }
         }
     }
 


### PR DESCRIPTION
If `actions.focus()` throws an error, we can assume something is wrong
and close the window.

REF: https://github.com/paypal/paypal-checkout/issues/845