### PR TITLE
chore(venmo-blacklist): Blacklisting barkbox from venmo

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -307,6 +307,10 @@ export let config = {
 
         'roku.com': {
             disable_venmo: true
+        },
+
+        'barkbox.com': {
+            disable_venmo: true
         }
     },
 


### PR DESCRIPTION
Hello, we have recently started using this library to support our PayPal payments for BarkBox. Because we are a subscription-based service using recurring payments/billing agreements, Venmo is not an option for us. Could you please have barkbox.com added to the blacklist? Thank you!