### PR TITLE
fix(inlineGuest): do not call onClick is buttons are disable

### DIFF
--- a/demo/disable.htm
+++ b/demo/disable.htm
@@ -1,0 +1,106 @@
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<div id="paypal-button"></div>
+
+<script src="http://localhost.paypal.com:9000/checkout.js"></script>
+<!-- <script src="https://www.paypalobjects.com/api/checkout.js"></script> -->
+
+<script>
+    var container = document.createElement('div');
+    var input = document.createElement('input');
+    var label = document.createElement('label');
+
+    input.type = 'checkbox';
+    label.innerHTML = 'check here to enable the buttons';
+
+    container.appendChild(input);
+    container.appendChild(label);
+
+    document.getElementById('paypal-button').appendChild(container);
+
+    let clicks = 0;
+
+    paypal.Button.render({
+
+        env: 'local', // Optional: specify 'sandbox' environment
+
+        locale: 'en_US',
+
+        commit: true, // Optional: show a 'Pay Now' button in the checkout flow
+
+        style: {
+            branding: true, // optional
+            layout: 'vertical',
+            size:  'responsive', // small | medium | large | responsive
+            shape: 'rect',   // pill | rect
+            color: 'gold'   // gold | blue | silve | black
+        },
+
+        client: {
+            sandbox: 'AWi18rxt26-hrueMoPZ0tpGEOJnNT4QkiMQst9pYgaQNAfS1FLFxkxQuiaqRBj1vV5PmgHX_jA_c1ncL',
+            stage: 'alc_client1',
+            local: 'alc_client1'
+        },
+
+        test: {
+          onRender(actions) {
+            actions.click();
+
+            input.addEventListener('change', () => {
+              setTimeout(() => {
+                actions.click();
+              }, 200);
+            });
+          }
+        },
+
+        onClick() {
+          console.log('on click');
+        },
+
+        validate(actions) {
+          actions.disable();
+
+          input.addEventListener('change', () => {
+            if (input.checked) {
+              actions.enable();
+            } else {
+              actions.disable();
+            }
+          });
+        },
+
+        payment(data, actions) { 
+            const transactions = [
+                {
+                    amount: {
+                        total: '3.00',
+                        currency: 'USD'
+                    },
+                    item_list: {
+                        items: [
+                            {
+                                name: 'Hat',
+                                description: 'A stylish brown hat.',
+                                quantity: '1',
+                                price: '3.00',
+                                sku: '12345',
+                                currency: 'USD'
+                            },
+                        ]
+                    }
+                }
+            ];
+
+            return actions.payment.create({
+                payment: { transactions }
+            });
+        },
+
+        onAuthorize(data, actions) { 
+            actions.payment.execute().then(data => {
+                // Show a success page to the buyer
+            });
+        }
+
+    }, '#paypal-button');
+</script>

--- a/src/hacks.js
+++ b/src/hacks.js
@@ -122,11 +122,19 @@ if (Button.xprops && Button.xprops.validate) {
         }
     });
 
+    // @TODO: this function will be redundant after checkoutjs v4.1.4x
+    // because we will change the way we enable/disable the buttons. We
+    // keep this only for the backward compatible and will remove it
+    // afterward
     patchMethod(Checkout, 'renderTo', ({ callOriginal }) => {
         if (enabled) {
             return callOriginal();
         }
         return new ZalgoPromise();
+    });
+
+    patchMethod(Button, 'isEnabled', () => {
+        return enabled;
     });
 }
 

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -376,7 +376,7 @@ export function patchWithOps(obj : ?Object, patch : Array<Patch>) : Object {
 }
 
 export function patchMethod(obj : Object, name : string, handler : Function) {
-    let original = obj[name];
+    let original = obj[name] || noop;
 
     obj[name] = function patchedMethod() : mixed {
         return handler({


### PR DESCRIPTION
- Fixes #976
- Refactor the way we disable/enable buttons by exposing the `isEnabled()` function for the Button component.
- Check the state of the buttons and return early if they're disabled.
- Demo page is included.
- Can be released independently with xo-buttonjs