### PR TITLE
fix(checkout-container): Lowering max-height for iframe container so that the close button is never hidden

### DIFF
--- a/src/checkout/template/containerStyle/base.js
+++ b/src/checkout/template/containerStyle/base.js
@@ -190,7 +190,7 @@ export function getContainerStyle({ id, tag, CONTEXT, CLASS, ANIMATION } : { id 
         #${ id }.${ tag }-context-${ CONTEXT.IFRAME } .paypal-checkout-iframe-container,
         #${ id }.${ tag }-context-${ CONTEXT.IFRAME } .paypal-checkout-iframe-container > .${ CLASS.OUTLET },
         #${ id }.${ tag }-context-${ CONTEXT.IFRAME } .paypal-checkout-iframe-container > .${ CLASS.OUTLET } > iframe {
-            max-height: 95vh;
+            max-height: calc(95vh - 60px);
             max-width: 95vw;
         }
 


### PR DESCRIPTION
RE: https://github.com/paypal/paypal-checkout/issues/639

Attached are screenshots that show the changes. The idea is to always give an extra 60px buffer to accommodate the close button in any scenario.

![95 viewport height](https://user-images.githubusercontent.com/1314484/50865485-c4211e80-135a-11e9-8983-24ed70f22bc5.png)
![95 viewport height, minus 60px](https://user-images.githubusercontent.com/1314484/50865486-c4211e80-135a-11e9-92fd-3c76b6f67fd6.png)
