### PR TITLE
Guard against falsy render param value for 'funding.allowed'

### DIFF
--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -471,7 +471,7 @@ export let Button : Component<ButtonOptions> = create({
 
                 let apmFunding = APM_FUNDING.filter(source => (isApmEligible(source, props)));
 
-                allowed = allowed.concat(apmFunding);
+                allowed = (allowed || []).concat(apmFunding);
 
                 let remembered = getRememberedFunding(sources => sources);
 


### PR DESCRIPTION
Fixes https://github.com/paypal/paypal-checkout/issues/1006

Guards against falsy values (e.g. `null`) passed as the `funding.allowed` parameter in the Button render code (similar to how `allowed` is checked for 16 lines above), to avoid breaking the render.