### PR TITLE
fix(button-component): Removing duplicate data attributes from card images.

### DIFF
--- a/src/button/template/componentTemplate.jsx
+++ b/src/button/template/componentTemplate.jsx
@@ -89,9 +89,6 @@ function renderCards({ cards, button, layout, size } :
                 class={ `${ button ? CLASS.BUTTON : '' } ${ CLASS.CARD } ${ CLASS.CARD }-${ name }` }
                 tabindex='0'>
                 <img
-                    { ...{ [ATTRIBUTE.LAYOUT]: layout ? layout : '' } }
-                    { ...{ [ATTRIBUTE.SIZE]: size ? size : '' } }
-                    { ...{ [ATTRIBUTE.BUTTON]: (button || false), [ATTRIBUTE.FUNDING_SOURCE]: `${ FUNDING.CARD }`, [ATTRIBUTE.CARD]: `${ name }` } }
                     style={ ` display: block; ` }
                     src={ `data:image/svg+xml;base64,${ btoa(logo) }` }
                     alt={ name } />


### PR DESCRIPTION
The data attributes were added to the images before we added proper event capture to the buttons. Now they are no-longer needed.